### PR TITLE
[Next Config] Caching redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ const nextConfig = {
       {
         source: '/',
         destination: '/login',
-        permanent: true,
+        permanent: false,
       },
     ];
   },


### PR DESCRIPTION
I suggest not caching redirect. After running InstruGo local server, redirect persisted and the only way I could remove that redirect for other web apps is to clear all browser cache.

[Next Issue #17069](https://github.com/vercel/next.js/issues/17069)