### PR TITLE
[Redesign] Lesson page modifications, navbar active tab highlight, fix caching lessons

### DIFF
--- a/localization/messages/en.json
+++ b/localization/messages/en.json
@@ -141,6 +141,7 @@
   "lessons.2nd_group": "In the next 7 days",
   "lessons.3rd_group": "Recently completed",
   "lessons.table": "Completed",
+  "lessons.noLessons": "No lessons.",
 
   "lessons.titles.subject": "Subject",
   "lessons.titles.dateAndTime": "Date And Time",

--- a/localization/messages/hr.json
+++ b/localization/messages/hr.json
@@ -142,6 +142,8 @@
   "lessons.2nd_group": "U sljedećih 7 dana",
   "lessons.3rd_group": "Nedavno završeno",
   "lessons.table": "Završeno",
+  "lessons.noLessons": "Nema instrukcija.",
+
   "lessons.titles.subject": "Predmet",
   "lessons.titles.dateAndTime": "Datum i vrijeme",
   "lessons.titles.subfield": "Područje",

--- a/pages/student/home.tsx
+++ b/pages/student/home.tsx
@@ -36,6 +36,6 @@ export default withAuth(StudentHomepage);
 export const PageLayout = styled('div', {
   padding: '20px',
   '> div + div': {
-    marginTop: '$10',
+    marginTop: '$24',
   },
 });

--- a/pages/student/lessons.tsx
+++ b/pages/student/lessons.tsx
@@ -4,10 +4,13 @@ import Head from 'next/head';
 import { TitledSection, withAuth } from '@components';
 import { LessonsContainer, Navbar } from '@modules';
 import { LessonsTable } from '@modules';
+import { lessonFilters } from '@utils/lessonFilters';
 
 import { PageLayout } from './home';
 
 const LessonsPage: NextPage = () => {
+  const { todayFilter, nextWeekFilter } = lessonFilters();
+
   return (
     <div>
       <Head>
@@ -18,15 +21,15 @@ const LessonsPage: NextPage = () => {
 
       <PageLayout>
         <TitledSection titleMsgId="lessons.1st_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={todayFilter} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.2nd_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={nextWeekFilter} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.3rd_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={{ status: 'completed' }} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.table">

--- a/pages/student/requests.tsx
+++ b/pages/student/requests.tsx
@@ -17,7 +17,14 @@ const RequestsPage: NextPage = () => {
 
       <PageLayout>
         <TitledSection titleMsgId="student.request.requests">
-          <NewRequestButton />
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <NewRequestButton />
+          </div>
 
           <LessonsContainer filter={{ status: 'requested' }} />
         </TitledSection>

--- a/pages/tutor/lessons.tsx
+++ b/pages/tutor/lessons.tsx
@@ -3,9 +3,12 @@ import Head from 'next/head';
 
 import { TitledSection, withAuth } from '@components';
 import { LessonsContainer, LessonsTable, Navbar } from '@modules';
+import { lessonFilters } from '@utils/lessonFilters';
 import { PageLayout } from 'pages/student/home';
 
 const LessonsPage: NextPage = () => {
+  const { todayFilter, nextWeekFilter } = lessonFilters();
+
   return (
     <div>
       <Head>
@@ -16,15 +19,15 @@ const LessonsPage: NextPage = () => {
 
       <PageLayout>
         <TitledSection titleMsgId="lessons.1st_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={todayFilter} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.2nd_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={nextWeekFilter} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.3rd_group">
-          <LessonsContainer filter={{ status: 'pending' }} />
+          <LessonsContainer filter={{ status: 'completed' }} />
         </TitledSection>
 
         <TitledSection titleMsgId="lessons.table">

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -10,10 +10,11 @@ import {
   DateNavigator,
   Resources,
 } from '@devexpress/dx-react-scheduler-material-ui';
-import { useLessons } from '@hooks';
 import Paper from '@mui/material/Paper';
 
-import { Lesson, TimeFrame } from '@types';
+import { Loader } from '@components';
+import { useLessons } from '@hooks';
+import { TimeFrame } from '@types';
 
 type TimeFrames = { timeFrame: TimeFrame; color: string; title: string }[];
 
@@ -30,7 +31,7 @@ interface CalendarProps {
  * @returns
  */
 export const Calendar = ({ pending, requestTimeframes }: CalendarProps) => {
-  const { data: lessons } = useLessons({ status: 'pending' });
+  const { data: lessons, isLoading } = useLessons({ status: 'pending' });
 
   const pendingTimeframes: TimeFrames | undefined = lessons?.map((lesson) => {
     return {
@@ -78,6 +79,10 @@ export const Calendar = ({ pending, requestTimeframes }: CalendarProps) => {
   const today = new Date().toISOString();
   const currentDate =
     schedulerData !== [] ? schedulerData[0]?.startDate : today;
+
+  if (isLoading) {
+    return <Loader />;
+  }
 
   return (
     <Paper>

--- a/src/components/titled-section/styles.ts
+++ b/src/components/titled-section/styles.ts
@@ -17,5 +17,5 @@ export const StyledHr = styled('hr', {
 });
 
 export const SectionContent = styled('div', {
-  marginTop: '$3',
+  marginTop: '$8',
 });

--- a/src/components/withAuth.tsx
+++ b/src/components/withAuth.tsx
@@ -28,6 +28,11 @@ export const withAuth = (Component: NextPage) => {
     };
 
     useEffect(() => {
+      queryClient.invalidateQueries('lessons');
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
       if (isError) {
         queryClient.invalidateQueries('profile');
       }

--- a/src/hooks/auth/useBecomeTutor.ts
+++ b/src/hooks/auth/useBecomeTutor.ts
@@ -1,11 +1,12 @@
 import { useRouter } from 'next/router';
 
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 import { useAxios, useUserContext } from '@hooks';
 import { User } from '@types';
 
 export const useBecomeTutor = () => {
+  const queryClient = useQueryClient();
   const axios = useAxios();
   const router = useRouter();
   const { setUser } = useUserContext();
@@ -23,6 +24,7 @@ export const useBecomeTutor = () => {
   return useMutation(becomeTutor, {
     onSuccess: (data) => {
       setUser(data);
+      queryClient.removeQueries('lessons');
       router.push('/tutor/home');
     },
     onError: (error) => {

--- a/src/modules/LessonsContainer/LessonsContainer.tsx
+++ b/src/modules/LessonsContainer/LessonsContainer.tsx
@@ -2,6 +2,7 @@ import { Loader } from '@components';
 import { useLessons } from '@hooks';
 import { LessonCard } from '@modules';
 import { LessonFilter } from '@types';
+import { FormattedMessage } from 'react-intl';
 import { styled } from 'styles/stitches.config';
 
 interface LessonsContainerProps {
@@ -15,9 +16,13 @@ export const LessonsContainer = ({ filter }: LessonsContainerProps) => {
 
   return (
     <StyledContainer>
-      {lessons?.map((lesson) => {
-        return <LessonCard key={lesson.id} lesson={lesson} />;
-      })}
+      {lessons && lessons.length !== 0 ? (
+        lessons.map((lesson) => {
+          return <LessonCard key={lesson.id} lesson={lesson} />;
+        })
+      ) : (
+        <FormattedMessage id="lessons.noLessons" />
+      )}
     </StyledContainer>
   );
 };

--- a/src/modules/LessonsTable/LessonsTable.tsx
+++ b/src/modules/LessonsTable/LessonsTable.tsx
@@ -67,45 +67,54 @@ export const LessonsTable = ({ filter }: LessonsTableProps) => {
             <FormattedMessage id="lessons.titles.rating" />
           </TableTitles>
         </TableHeader>
-        {lessons.map((lesson) => {
-          const date = new Date(lesson.finalStartTime);
-          const rating =
-            lesson.rating && lesson.rating.studentRating
-              ? lesson.rating.studentRating
-              : '';
-          return (
-            <TableItem
-              key={lesson.id}
-              onClick={() => setLessonDetailsModal(true)}
-            >
-              <TableData>{lesson.subject.name}</TableData>
-              <TableData>{lesson.subfield}</TableData>
-              <TableData>
-                {`${date.getDate()}\/${date.getMonth()}\/${date.getFullYear()}`}
-                {',   '}
-                {`${date.getHours()}:${date.getMinutes()}`}
-              </TableData>
-              <TableData>{'0kn'}</TableData>
-              <TableData>{lesson.location}</TableData>
-              <TableData>
-                <FormattedMessage id={`meetingType.${lesson.type}`} />
-              </TableData>
-              <TableData>
-                <FormattedMessage
-                  id={`educationLevel.${lesson.educationLevel}`}
-                />
-              </TableData>
-              <TableData>{lesson.grade}</TableData>
-              <TableData>{rating}</TableData>
-              <Modal
-                shouldShow={showLessonDetailsModal}
-                closeAction={() => setLessonDetailsModal(false)}
+
+        {lessons.length !== 0 ? (
+          lessons.map((lesson) => {
+            const date = new Date(lesson.finalStartTime);
+            const rating =
+              lesson.rating && lesson.rating.studentRating
+                ? lesson.rating.studentRating
+                : '';
+            return (
+              <TableItem
+                key={lesson.id}
+                onClick={() => setLessonDetailsModal(true)}
               >
-                <LessonDetails id={lesson.id} />
-              </Modal>
-            </TableItem>
-          );
-        })}
+                <TableData>{lesson.subject.name}</TableData>
+                <TableData>{lesson.subfield}</TableData>
+                <TableData>
+                  {`${date.getDate()}\/${date.getMonth()}\/${date.getFullYear()}`}
+                  {',   '}
+                  {`${date.getHours()}:${date.getMinutes()}`}
+                </TableData>
+                <TableData>{'0kn'}</TableData>
+                <TableData>{lesson.location}</TableData>
+                <TableData>
+                  <FormattedMessage id={`meetingType.${lesson.type}`} />
+                </TableData>
+                <TableData>
+                  <FormattedMessage
+                    id={`educationLevel.${lesson.educationLevel}`}
+                  />
+                </TableData>
+                <TableData>{lesson.grade}</TableData>
+                <TableData>{rating}</TableData>
+                <Modal
+                  shouldShow={showLessonDetailsModal}
+                  closeAction={() => setLessonDetailsModal(false)}
+                >
+                  <LessonDetails id={lesson.id} />
+                </Modal>
+              </TableItem>
+            );
+          })
+        ) : (
+          <TableItem>
+            <TableData>
+              <FormattedMessage id="lessons.noLessons" />
+            </TableData>
+          </TableItem>
+        )}
       </TableBody>
     </TableStyle>
   );

--- a/src/modules/Navbar/Navbar.tsx
+++ b/src/modules/Navbar/Navbar.tsx
@@ -5,6 +5,7 @@ import { BsPersonCircle } from 'react-icons/bs';
 import { GiHamburgerMenu } from 'react-icons/gi';
 import { HiOutlineSwitchVertical } from 'react-icons/hi';
 import { FormattedMessage } from 'react-intl';
+import { useQueryClient } from 'react-query';
 
 import { Button, CustomLink, HeaderContainer, Loader } from '@components';
 import {
@@ -19,6 +20,7 @@ import {
   Clickable,
   HamburgerMenu,
   NavLink,
+  NavLinkDecorator,
   OpenedMenu,
   OpenedProfileMenu,
   ProfileLink,
@@ -28,6 +30,7 @@ import {
 } from './styles';
 
 export const Navbar = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
   const logout = useLogout();
   const becomeTutor = useBecomeTutor();
@@ -65,8 +68,13 @@ export const Navbar = () => {
     if (user?.role === UserRole.STUDENT) {
       becomeATutor();
     } else {
-      if (router.pathname.startsWith('/student')) router.push('/tutor/home');
-      else router.push('/student/home');
+      queryClient.removeQueries('lessons');
+
+      if (router.pathname.startsWith('/student')) {
+        router.push('/tutor/home');
+      } else {
+        router.push('/student/home');
+      }
     }
   };
 
@@ -76,6 +84,8 @@ export const Navbar = () => {
       : router.pathname.startsWith('/student')
       ? 'nav.switchToTutor'
       : 'nav.switchToStudent';
+
+  const currentUrl = router.pathname;
 
   if (!user) {
     return <Loader />;
@@ -87,44 +97,100 @@ export const Navbar = () => {
         {user.role === UserRole.STUDENT ||
         router.pathname.startsWith('/student') ? (
           <StyledNavbar>
-            <NavLink>
-              <CustomLink href="/student/home">
-                <FormattedMessage id={'nav.home'} />
-              </CustomLink>
-            </NavLink>
-            <NavLink>
-              <CustomLink href="/student/lessons">
-                <FormattedMessage id={'nav.myLessons'} />
-              </CustomLink>
-            </NavLink>
-            <NavLink>
-              <CustomLink href="/student/requests">
-                <FormattedMessage id={'nav.myRequests'} />
-              </CustomLink>
-            </NavLink>
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/student/home' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/student/home">
+                  <FormattedMessage id={'nav.home'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
+
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/student/lessons' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/student/lessons">
+                  <FormattedMessage id={'nav.myLessons'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
+
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/student/requests'
+                    ? '#06333c'
+                    : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/student/requests">
+                  <FormattedMessage id={'nav.myRequests'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
           </StyledNavbar>
         ) : (
           <StyledNavbar>
-            <NavLink>
-              <CustomLink href="/tutor/home">
-                <FormattedMessage id={'nav.home'} />
-              </CustomLink>
-            </NavLink>
-            <NavLink>
-              <CustomLink href="/tutor/lessons">
-                <FormattedMessage id={'nav.myLessons'} />
-              </CustomLink>
-            </NavLink>
-            <NavLink>
-              <CustomLink href="/tutor/requests">
-                <FormattedMessage id={'nav.publicRequests'} />
-              </CustomLink>
-            </NavLink>
-            <NavLink>
-              <CustomLink href="/tutor/responses">
-                <FormattedMessage id={'nav.tutorResponses'} />
-              </CustomLink>
-            </NavLink>
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/tutor/home' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/tutor/home">
+                  <FormattedMessage id={'nav.home'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
+
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/tutor/lessons' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/tutor/lessons">
+                  <FormattedMessage id={'nav.myLessons'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
+
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/tutor/requests' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/tutor/requests">
+                  <FormattedMessage id={'nav.publicRequests'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
+
+            <NavLinkDecorator
+              style={{
+                backgroundColor:
+                  currentUrl === '/tutor/responses' ? '#06333c' : 'transparent',
+              }}
+            >
+              <NavLink>
+                <CustomLink href="/tutor/responses">
+                  <FormattedMessage id={'nav.tutorResponses'} />
+                </CustomLink>
+              </NavLink>
+            </NavLinkDecorator>
           </StyledNavbar>
         )}
 

--- a/src/modules/Navbar/styles.ts
+++ b/src/modules/Navbar/styles.ts
@@ -12,9 +12,17 @@ export const StyledNavbar = styled('div', {
     display: 'flex',
   },
   alignItems: 'center',
-  'div + div': {
-    marginLeft: '30px',
+  '> div + div': {
+    marginLeft: '$3',
   },
+});
+
+export const NavLinkDecorator = styled('div', {
+  height: '$full',
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0 $3',
+  borderRadius: '5px',
 });
 
 export const NavLink = styled('div', {

--- a/src/modules/PublicRequestsContainer/styles.tsx
+++ b/src/modules/PublicRequestsContainer/styles.tsx
@@ -19,7 +19,7 @@ export const StyledHr = styled('hr', {
 });
 
 export const RequestsBody = styled('div', {
-  marginTop: '$4',
+  marginTop: '$10',
   display: 'flex',
   flexWrap: 'wrap',
   gap: '$6',

--- a/src/utils/lessonFilters.ts
+++ b/src/utils/lessonFilters.ts
@@ -1,0 +1,28 @@
+export const lessonFilters = () => {
+  const now = new Date();
+
+  // Today filter
+  // From midnight today to midnight tomorrow
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayEnd = new Date();
+  todayEnd.setDate(now.getDate() + 1);
+  todayEnd.setUTCHours(0, 0, 0, 0);
+
+  const todayFilter = {
+    status: 'pending',
+    after: todayStart.toISOString(),
+    before: todayEnd.toISOString(),
+  };
+
+  // Next week filter
+  const weekAfterDate = new Date();
+  weekAfterDate.setDate(now.getDate() + 7);
+
+  const nextWeekFilter = {
+    status: 'pending',
+    before: weekAfterDate.toISOString(),
+  };
+
+  return { todayFilter, nextWeekFilter };
+};


### PR DESCRIPTION
Solved tasks:
- [INGO-72](https://instrugo.atlassian.net/browse/INGO-72)
- [INGO-77](https://instrugo.atlassian.net/browse/INGO-77)
- [INGO-96](https://instrugo.atlassian.net/browse/INGO-96)

Additional work:
- lessons query data is removed from cache on every student-tutor switch action, now lessons fetch correctly with `isLessonTutor` param
- added empty state for `LessonContainer` and `LessonsTable`
- lessons page now properly filters lessons by date and time